### PR TITLE
edit: unit_scale to be 1024 based not 1000

### DIFF
--- a/tqdm/_tqdm.py
+++ b/tqdm/_tqdm.py
@@ -154,7 +154,7 @@ class tqdm(object):
                         return '{0:1.2f}'.format(num) + unit + suffix
                     return '{0:2.1f}'.format(num) + unit + suffix
                 return '{0:3.0f}'.format(num) + unit + suffix
-            num /= 1000.0
+            num /= 1024.0
         return '{0:3.1f}Y'.format(num) + suffix
 
     @staticmethod


### PR DESCRIPTION
file size of 81893785 
Using 1024 base it's 78.1 MB which is used by most file explorers, 
while the current 1000 based gives 81.9 MB which causes confusion.

- [ +] I have visited the [source website], and in particular
  read the [known issues]
- [ +] I have searched through the [issue tracker] for duplicates
- [ +] If applicable, I have mentioned the relevant/related issue(s) in this PR

  [source website]: https://github.com/tqdm/tqdm/
  [known issues]: https://github.com/tqdm/tqdm/#help
  [issue tracker]: https://github.com/tqdm/tqdm/issues?q=
